### PR TITLE
Allow scriptsPath to be configurable for use with godep etc.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,13 +1,23 @@
 package zoom
 
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	scriptsPath = filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "albrow", "zoom", "scripts")
+)
+
 // defaultConfiguration holds the default values for each config option
 // if the zero value is provided in the input configuration, the value
 // will fallback to the default value
 var defaultConfiguration = Configuration{
-	Address:  "localhost:6379",
-	Network:  "tcp",
-	Database: 0,
-	Password: "",
+	Address:     "localhost:6379",
+	Network:     "tcp",
+	Database:    0,
+	Password:    "",
+	ScriptsPath: "",
 }
 
 // parseConfig returns a well-formed configuration struct.
@@ -18,14 +28,22 @@ func parseConfig(passedConfig *Configuration) *Configuration {
 	if passedConfig == nil {
 		return &defaultConfiguration
 	}
+
 	// copy the passedConfig
 	newConfig := *passedConfig
+
 	if newConfig.Address == "" {
 		newConfig.Address = defaultConfiguration.Address
 	}
+
 	if newConfig.Network == "" {
 		newConfig.Network = defaultConfiguration.Network
 	}
+
+	if newConfig.ScriptsPath == "" {
+		newConfig.ScriptsPath = scriptsPath
+	}
+
 	// since the zero value for int is 0, we can skip config.Database
 	// since the zero value for string is "", we can skip config.Address
 	return &newConfig
@@ -44,4 +62,8 @@ type Configuration struct {
 	// every connection will use the AUTH command during initialization
 	// to authenticate with the database. Default: ""
 	Password string
+
+	// ScriptsPath for location of lua scripts to load
+	// Default: $GOPATH/src/github.com/albrow/zoom/scripts
+	ScriptsPath string
 }

--- a/scripts.go
+++ b/scripts.go
@@ -9,10 +9,10 @@
 package zoom
 
 import (
-	"github.com/garyburd/redigo/redis"
 	"io/ioutil"
-	"os"
 	"path/filepath"
+
+	"github.com/garyburd/redigo/redis"
 )
 
 var (
@@ -22,13 +22,9 @@ var (
 	extractIdsFromStringIndexScript *redis.Script
 )
 
-var (
-	scriptsPath = filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "albrow", "zoom", "scripts")
-)
-
 // initScripts will parse all the lua script files in scriptsPath and assign them
 // to the variables above. It must be run before any scripts are executed.
-func initScripts() error {
+func initScripts(scriptsPath string) error {
 	scriptsToParse := []struct {
 		script   **redis.Script
 		filename string

--- a/zoom.go
+++ b/zoom.go
@@ -16,7 +16,7 @@ package zoom
 func Init(config *Configuration) error {
 	config = parseConfig(config)
 	initPool(config.Network, config.Address, config.Database, config.Password)
-	if err := initScripts(); err != nil {
+	if err := initScripts(config.ScriptsPath); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
I use godep for all of my project deps and godep has one other dir before src. (`_wordspace`). Not sure if this is the best solution for something like this but I guess it's a conversation starter.