### PR TITLE
Support go 1.6 changes to reflect. Fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ type Person struct {
 }
 ```
 
-Because of the way Zoom uses reflection, all the fields you want to save need to be public. Almost
+Because of the way Zoom uses reflection, all the fields you want to save need to be exported.
+Unexported fields (including unexported embedded structs with exported fields) will not
+be saved. This is a departure from how the  encoding/json and  encoding/xml packages
+behave. See [issue #25](https://github.com/albrow/zoom/issues/25) for discussion. Almost
 any type of field is supported, including custom types, slices, maps, complex types, and embedded
 structs. The only things that are not supported are recursive data structures and functions.
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -86,7 +86,7 @@ func TestJSONFallback(t *testing.T) {
 	testConvertType(t, jsonModels, model)
 }
 
-type embeddable struct {
+type Embeddable struct {
 	Int    int
 	String string
 	Bool   bool
@@ -97,7 +97,7 @@ func TestConvertEmbeddedStruct(t *testing.T) {
 	defer testingTearDown()
 
 	type embeddedStructModel struct {
-		embeddable
+		Embeddable
 		RandomId
 	}
 	embededStructModels, err := testPool.NewCollection(&embeddedStructModel{}, nil)
@@ -105,7 +105,7 @@ func TestConvertEmbeddedStruct(t *testing.T) {
 		t.Errorf("Unexpected error in testPool.NewCollection: %s", err.Error())
 	}
 	model := &embeddedStructModel{
-		embeddable: embeddable{
+		Embeddable: Embeddable{
 			Int:    randomInt(),
 			String: randomString(),
 			Bool:   randomBool(),
@@ -119,7 +119,7 @@ func TestEmbeddedPointerToStruct(t *testing.T) {
 	defer testingTearDown()
 
 	type embeddedPointerToStructModel struct {
-		*embeddable
+		*Embeddable
 		RandomId
 	}
 	embededPointerToStructModels, err := testPool.NewCollection(&embeddedPointerToStructModel{}, nil)
@@ -127,7 +127,7 @@ func TestEmbeddedPointerToStruct(t *testing.T) {
 		t.Errorf("Unexpected error in testPool.NewCollection: %s", err.Error())
 	}
 	model := &embeddedPointerToStructModel{
-		embeddable: &embeddable{
+		Embeddable: &Embeddable{
 			Int:    randomInt(),
 			String: randomString(),
 			Bool:   randomBool(),

--- a/model.go
+++ b/model.go
@@ -99,8 +99,12 @@ func compileModelSpec(typ reflect.Type) (*modelSpec, error) {
 	numFields := elem.NumField()
 	for i := 0; i < numFields; i++ {
 		field := elem.Field(i)
-		// Skip unexported fields
-		if field.PkgPath != "" {
+		// Skip unexported fields. Prior to go 1.6, field.PkgPath won't give us
+		// the behavior we want. Unlike packages such as encoding/json and
+		// encoding/gob, Zoom does not save unexported embedded structs with
+		// exported fields. So instead, we check if the first character of the
+		// field name is lowercase.
+		if strings.ToLower(field.Name[0:1]) == field.Name[0:1] {
 			continue
 		}
 

--- a/model_test.go
+++ b/model_test.go
@@ -44,6 +44,15 @@ func TestCompileModelSpec(t *testing.T) {
 		String string `redis:"myString"`
 		Bool   bool   `redis:"myBool"`
 	}
+	type Embedded struct {
+		Primative
+	}
+	type private struct {
+		Int int
+	}
+	type EmbeddedPrivate struct {
+		private
+	}
 	testCases := []struct {
 		model        interface{}
 		expectedSpec *modelSpec
@@ -274,6 +283,39 @@ func TestCompileModelSpec(t *testing.T) {
 						indexKind: noIndex,
 					},
 				},
+			},
+		},
+		{
+			model: &Embedded{},
+			expectedSpec: &modelSpec{
+				typ:  reflect.TypeOf(&Embedded{}),
+				name: "Embedded",
+				fieldsByName: map[string]*fieldSpec{
+					"Primative": {
+						kind:      inconvertibleField,
+						name:      "Primative",
+						redisName: "Primative",
+						typ:       reflect.TypeOf(Primative{}),
+						indexKind: noIndex,
+					},
+				},
+				fields: []*fieldSpec{
+					{
+						kind:      inconvertibleField,
+						name:      "Primative",
+						redisName: "Primative",
+						typ:       reflect.TypeOf(Primative{}),
+						indexKind: noIndex,
+					},
+				},
+			},
+		},
+		{
+			model: &EmbeddedPrivate{},
+			expectedSpec: &modelSpec{
+				typ:          reflect.TypeOf(&EmbeddedPrivate{}),
+				name:         "EmbeddedPrivate",
+				fieldsByName: map[string]*fieldSpec{},
 			},
 		},
 	}


### PR DESCRIPTION
Also elaborate on current treatment of unexported embedded structs with exported fields.